### PR TITLE
[#10] 소셜 로그인 + JWT 발급 및 회원가입 구현

### DIFF
--- a/src/main/java/yagu/yagu/common/security/CustomOAuth2User.java
+++ b/src/main/java/yagu/yagu/common/security/CustomOAuth2User.java
@@ -8,55 +8,38 @@ import org.springframework.security.oauth2.core.user.OAuth2User;
 import yagu.yagu.user.entity.User;
 
 import java.util.Collection;
-import java.util.Collections;
+import java.util.List;
 import java.util.Map;
 
 @Getter
 public class CustomOAuth2User implements OAuth2User, UserDetails {
-
     private final User user;
-    private final Map<String, Object> attributes;
+    private final Map<String, Object> attrs;
 
-    public CustomOAuth2User(User user, Map<String, Object> attributes) {
+    public CustomOAuth2User(User user, Map<String, Object> attrs) {
         this.user = user;
-        this.attributes = attributes;
+        this.attrs = attrs;
+    }
+
+    @Override
+    public Map<String, Object> getAttributes() {
+        return attrs;
     }
 
     @Override
     public Collection<? extends GrantedAuthority> getAuthorities() {
-        return Collections.singletonList(new SimpleGrantedAuthority("USER"));
+        return List.of(new SimpleGrantedAuthority("ROLE_USER"));
     }
 
-    @Override
-    public String getPassword() {
-        return null;
-    }
+    // UserDetails 인터페이스 메서드
+    @Override public String getPassword()               { return null; }
+    @Override public String getUsername()               { return user.getEmail(); }
+    @Override public boolean isAccountNonExpired()      { return true; }
+    @Override public boolean isAccountNonLocked()       { return true; }
+    @Override public boolean isCredentialsNonExpired()  { return true; }
+    @Override public boolean isEnabled()                { return true; }
 
-    @Override
-    public String getUsername() {
-        return user.getEmail();
-    }
-
-    @Override
-    public boolean isAccountNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isAccountNonLocked() {
-        return true;
-    }
-
-    @Override
-    public boolean isCredentialsNonExpired() {
-        return true;
-    }
-
-    @Override
-    public boolean isEnabled() {
-        return true;
-    }
-
+    // OAuth2User 인터페이스 메서드
     @Override
     public String getName() {
         return user.getEmail();

--- a/src/main/java/yagu/yagu/common/security/CustomOAuth2UserService.java
+++ b/src/main/java/yagu/yagu/common/security/CustomOAuth2UserService.java
@@ -1,11 +1,9 @@
 package yagu.yagu.common.security;
 
 import lombok.RequiredArgsConstructor;
-import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
-import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import yagu.yagu.user.entity.User;
@@ -17,44 +15,23 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final AuthService authService;
-    private final OidcUserService oidcDelegate = new OidcUserService();
 
-    // 1) 카카오·그 외 OAuth2 로그인 처리
     @Override
-    public OAuth2User loadUser(OAuth2UserRequest request) {
+    public OAuth2User loadUser(OAuth2UserRequest request) throws OAuth2AuthenticationException {
         OAuth2User oauth2User = super.loadUser(request);
-        return buildCustomUser(
-                oauth2User.getAttributes(),
-                request.getClientRegistration().getRegistrationId()
-        );
-    }
+        Map<String, Object> attrs = oauth2User.getAttributes();
+        String provider = request.getClientRegistration().getRegistrationId();
 
-    // 2) 구글·애플 OIDC 로그인 처리
-    public OidcUser loadUser(OidcUserRequest request) {
-        OidcUser oidcUser = oidcDelegate.loadUser(request);
-        return (OidcUser) buildCustomUser(
-                oidcUser.getAttributes(),
-                request.getClientRegistration().getRegistrationId()
+        // 이메일, 닉네임, providerId 추출 로직
+        String email = (String) ((provider.equals("kakao"))
+                ? ((Map<?, ?>) attrs.get("kakao_account")).get("email")
+                : attrs.get("email"));
+        String nick  = (String) ((provider.equals("kakao"))
+                ? ((Map<?, ?>) attrs.get("properties")).get("nickname")
+                : attrs.getOrDefault("name", email));
+        String pid   = (String) String.valueOf(
+                provider.equals("kakao") ? attrs.get("id") : attrs.get("sub")
         );
-    }
-
-    // 공통 래핑 로직
-    private CustomOAuth2User buildCustomUser(Map<String, Object> attrs, String provider) {
-        String email = switch (provider) {
-            case "google", "apple" -> (String) attrs.get("email");
-            case "kakao"           -> (String) ((Map<?, ?>) attrs.get("kakao_account")).get("email");
-            default                -> throw new IllegalArgumentException("지원하지 않는 프로바이더: " + provider);
-        };
-        String nick = switch (provider) {
-            case "google", "apple" -> (String) attrs.get("name");
-            case "kakao"           -> (String) ((Map<?, ?>) attrs.get("properties")).get("nickname");
-            default                -> email;
-        };
-        String pid = switch (provider) {
-            case "google", "apple" -> (String) attrs.get("sub");
-            case "kakao"           -> String.valueOf(attrs.get("id"));
-            default                -> null;
-        };
 
         User user = authService.findOrCreateUser(
                 email,

--- a/src/main/java/yagu/yagu/common/security/CustomOAuth2UserService.java
+++ b/src/main/java/yagu/yagu/common/security/CustomOAuth2UserService.java
@@ -1,8 +1,11 @@
 package yagu.yagu.common.security;
 
 import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import yagu.yagu.user.entity.User;
@@ -14,39 +17,51 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
     private final AuthService authService;
+    private final OidcUserService oidcDelegate = new OidcUserService();
 
+    // 1) 카카오·그 외 OAuth2 로그인 처리
     @Override
-    public OAuth2User loadUser(OAuth2UserRequest req) {
-        OAuth2User oAuth2 = super.loadUser(req);
-        String provider = req.getClientRegistration().getRegistrationId();
-        Map<String,Object> a = oAuth2.getAttributes();
+    public OAuth2User loadUser(OAuth2UserRequest request) {
+        OAuth2User oauth2User = super.loadUser(request);
+        return buildCustomUser(
+                oauth2User.getAttributes(),
+                request.getClientRegistration().getRegistrationId()
+        );
+    }
 
-        // 이메일
-        String email = switch(provider) {
-            case "google" -> (String) a.get("email");
-            case "kakao"  -> (String)((Map<?,?>)a.get("kakao_account")).get("email");
-            case "apple"  -> (String) a.get("email");
-            default -> throw new RuntimeException("지원 안 함");
+    // 2) 구글·애플 OIDC 로그인 처리
+    public OidcUser loadUser(OidcUserRequest request) {
+        OidcUser oidcUser = oidcDelegate.loadUser(request);
+        return (OidcUser) buildCustomUser(
+                oidcUser.getAttributes(),
+                request.getClientRegistration().getRegistrationId()
+        );
+    }
+
+    // 공통 래핑 로직
+    private CustomOAuth2User buildCustomUser(Map<String, Object> attrs, String provider) {
+        String email = switch (provider) {
+            case "google", "apple" -> (String) attrs.get("email");
+            case "kakao"           -> (String) ((Map<?, ?>) attrs.get("kakao_account")).get("email");
+            default                -> throw new IllegalArgumentException("지원하지 않는 프로바이더: " + provider);
         };
-        // 닉네임
-        String nick = switch(provider) {
-            case "google" -> (String) a.get("name");
-            case "kakao"  -> (String)((Map<?,?>)a.get("properties")).get("nickname");
-            case "apple"  -> (String) a.get("name");
-            default -> email;
+        String nick = switch (provider) {
+            case "google", "apple" -> (String) attrs.get("name");
+            case "kakao"           -> (String) ((Map<?, ?>) attrs.get("properties")).get("nickname");
+            default                -> email;
         };
-        // 프로바이더 ID
-        String pid = switch(provider) {
-            case "google","apple" -> (String) a.get("sub");
-            case "kakao"         -> String.valueOf(a.get("id"));
-            default -> null;
+        String pid = switch (provider) {
+            case "google", "apple" -> (String) attrs.get("sub");
+            case "kakao"           -> String.valueOf(attrs.get("id"));
+            default                -> null;
         };
 
         User user = authService.findOrCreateUser(
-                email, nick,
+                email,
+                nick,
                 User.AuthProvider.valueOf(provider.toUpperCase()),
                 pid
         );
-        return new CustomOAuth2User(user, a);
+        return new CustomOAuth2User(user, attrs);
     }
 }

--- a/src/main/java/yagu/yagu/common/security/CustomOAuth2UserService.java
+++ b/src/main/java/yagu/yagu/common/security/CustomOAuth2UserService.java
@@ -3,7 +3,6 @@ package yagu.yagu.common.security;
 import lombok.RequiredArgsConstructor;
 import org.springframework.security.oauth2.client.userinfo.DefaultOAuth2UserService;
 import org.springframework.security.oauth2.client.userinfo.OAuth2UserRequest;
-import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Service;
 import yagu.yagu.user.entity.User;
@@ -14,57 +13,40 @@ import java.util.Map;
 @Service
 @RequiredArgsConstructor
 public class CustomOAuth2UserService extends DefaultOAuth2UserService {
-
     private final AuthService authService;
 
     @Override
-    public OAuth2User loadUser(OAuth2UserRequest userRequest) throws OAuth2AuthenticationException {
-        OAuth2User oAuth2User = super.loadUser(userRequest);
-        String provider = userRequest.getClientRegistration().getRegistrationId();
+    public OAuth2User loadUser(OAuth2UserRequest req) {
+        OAuth2User oAuth2 = super.loadUser(req);
+        String provider = req.getClientRegistration().getRegistrationId();
+        Map<String,Object> a = oAuth2.getAttributes();
 
-        Map<String, Object> attributes = oAuth2User.getAttributes();
-        System.out.println("카카오 attributes: " + attributes);
-        String email = getEmail(attributes, provider);
-        String nickname = getNickname(attributes, provider);
-        String providerId = getProviderId(attributes, provider);
-        System.out.println("파싱 결과 - email: " + email + ", nickname: " + nickname + ", providerId: " + providerId);
+        // 이메일
+        String email = switch(provider) {
+            case "google" -> (String) a.get("email");
+            case "kakao"  -> (String)((Map<?,?>)a.get("kakao_account")).get("email");
+            case "apple"  -> (String) a.get("email");
+            default -> throw new RuntimeException("지원 안 함");
+        };
+        // 닉네임
+        String nick = switch(provider) {
+            case "google" -> (String) a.get("name");
+            case "kakao"  -> (String)((Map<?,?>)a.get("properties")).get("nickname");
+            case "apple"  -> (String) a.get("name");
+            default -> email;
+        };
+        // 프로바이더 ID
+        String pid = switch(provider) {
+            case "google","apple" -> (String) a.get("sub");
+            case "kakao"         -> String.valueOf(a.get("id"));
+            default -> null;
+        };
 
         User user = authService.findOrCreateUser(
-                email,
-                nickname,
+                email, nick,
                 User.AuthProvider.valueOf(provider.toUpperCase()),
-                providerId
+                pid
         );
-
-        return new CustomOAuth2User(user, attributes);
-    }
-
-    private String getEmail(Map<String, Object> attributes, String provider) {
-        if (provider.equals("kakao")) {
-            Map<String, Object> kakaoAccount = (Map<String, Object>) attributes.get("kakao_account");
-            return (String) kakaoAccount.get("email");
-        } else if (provider.equals("apple")) {
-            return (String) attributes.get("email");
-        }
-        return null;
-    }
-
-    private String getNickname(Map<String, Object> attributes, String provider) {
-        if (provider.equals("kakao")) {
-            Map<String, Object> properties = (Map<String, Object>) attributes.get("properties");
-            return (String) properties.get("nickname");
-        } else if (provider.equals("apple")) {
-            return (String) attributes.get("name");
-        }
-        return null;
-    }
-
-    private String getProviderId(Map<String, Object> attributes, String provider) {
-        if (provider.equals("kakao")) {
-            return String.valueOf(attributes.get("id"));
-        } else if (provider.equals("apple")) {
-            return (String) attributes.get("sub");
-        }
-        return null;
+        return new CustomOAuth2User(user, a);
     }
 }

--- a/src/main/java/yagu/yagu/common/security/CustomOidcUser.java
+++ b/src/main/java/yagu/yagu/common/security/CustomOidcUser.java
@@ -1,0 +1,33 @@
+package yagu.yagu.common.security;
+
+import org.springframework.security.oauth2.core.oidc.OidcIdToken;
+import org.springframework.security.oauth2.core.oidc.OidcUserInfo;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import yagu.yagu.user.entity.User;
+
+import java.util.Map;
+
+public class CustomOidcUser extends CustomOAuth2User implements OidcUser {
+    private final OidcUser oidcUser;
+
+    public CustomOidcUser(User user, OidcUser oidcUser) {
+        super(user, oidcUser.getAttributes());
+        this.oidcUser = oidcUser;
+    }
+
+    @Override
+    public Map<String, Object> getClaims() {
+        return oidcUser.getClaims();
+    }
+
+    @Override
+    public OidcIdToken getIdToken() {
+        return oidcUser.getIdToken();
+    }
+
+    @Override
+    public OidcUserInfo getUserInfo() {
+        return oidcUser.getUserInfo();
+    }
+}
+

--- a/src/main/java/yagu/yagu/common/security/CustomOidcUserService.java
+++ b/src/main/java/yagu/yagu/common/security/CustomOidcUserService.java
@@ -1,0 +1,38 @@
+package yagu.yagu.common.security;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserRequest;
+import org.springframework.security.oauth2.client.oidc.userinfo.OidcUserService;
+import org.springframework.security.oauth2.core.OAuth2AuthenticationException;
+import org.springframework.security.oauth2.core.oidc.user.OidcUser;
+import org.springframework.stereotype.Service;
+import yagu.yagu.user.entity.User;
+import yagu.yagu.user.service.AuthService;
+
+import java.util.Map;
+
+@Service
+@RequiredArgsConstructor
+public class CustomOidcUserService implements org.springframework.security.oauth2.client.userinfo.OAuth2UserService<OidcUserRequest, OidcUser> {
+    private final AuthService authService;
+    private final OidcUserService delegate = new OidcUserService();
+
+    @Override
+    public OidcUser loadUser(OidcUserRequest request) throws OAuth2AuthenticationException {
+        OidcUser oidcUser = delegate.loadUser(request);
+        Map<String, Object> attrs = oidcUser.getAttributes();
+        String provider = request.getClientRegistration().getRegistrationId();
+
+        String email = (String) attrs.get("email");
+        String nick  = (String) attrs.getOrDefault("name", email);
+        String pid   = (String) attrs.get("sub");
+
+        User user = authService.findOrCreateUser(
+                email,
+                nick,
+                User.AuthProvider.valueOf(provider.toUpperCase()),
+                pid
+        );
+        return new CustomOidcUser(user, oidcUser);
+    }
+}

--- a/src/main/java/yagu/yagu/common/security/CustomUserDetailsService.java
+++ b/src/main/java/yagu/yagu/common/security/CustomUserDetailsService.java
@@ -10,20 +10,16 @@ import yagu.yagu.user.repository.UserRepository;
 
 import java.util.Collections;
 
+
 @Service
 @RequiredArgsConstructor
 public class CustomUserDetailsService implements UserDetailsService {
-
-    private final UserRepository userRepository;
+    private final UserRepository repo;
 
     @Override
     public UserDetails loadUserByUsername(String email) throws UsernameNotFoundException {
-        User user = userRepository.findByEmail(email)
+        var u = repo.findByEmail(email)
                 .orElseThrow(() -> new UsernameNotFoundException("no user: " + email));
-
-        return new CustomOAuth2User(
-                user,
-                Collections.singletonMap("email", user.getEmail())
-        );
+        return new CustomOAuth2User(u, Collections.singletonMap("email", email));
     }
 }

--- a/src/main/java/yagu/yagu/common/security/SecurityConfig.java
+++ b/src/main/java/yagu/yagu/common/security/SecurityConfig.java
@@ -47,7 +47,10 @@ public class SecurityConfig {
                 .oauth2Login(oauth2 -> oauth2
                         .authorizationEndpoint(a -> a.baseUri("/oauth2/authorization"))
                         .redirectionEndpoint(r -> r.baseUri("/login/oauth2/code/*"))
-                        .userInfoEndpoint(u -> u.userService(oauth2UserService))
+                        .userInfoEndpoint(u -> u
+                                .userService(oauth2UserService)
+                                .oidcUserService(oauth2UserService)
+                        )
                         .successHandler(this::onSuccess)
                         .failureHandler(this::onFailure)
                 )

--- a/src/main/java/yagu/yagu/common/security/SecurityConfig.java
+++ b/src/main/java/yagu/yagu/common/security/SecurityConfig.java
@@ -27,9 +27,9 @@ import java.util.Map;
 @EnableWebSecurity
 @RequiredArgsConstructor
 public class SecurityConfig {
-
     private final JwtTokenProvider jwtProvider;
     private final CustomOAuth2UserService oauth2UserService;
+    private final CustomOidcUserService oidcUserService;
     private final AuthService authService;
     private final ObjectMapper mapper;
 
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .redirectionEndpoint(r -> r.baseUri("/login/oauth2/code/*"))
                         .userInfoEndpoint(u -> u
                                 .userService(oauth2UserService)
-                                .oidcUserService(oauth2UserService::loadUser)
+                                .oidcUserService(oidcUserService)
                         )
                         .successHandler(this::onSuccess)
                         .failureHandler(this::onFailure)

--- a/src/main/java/yagu/yagu/common/security/SecurityConfig.java
+++ b/src/main/java/yagu/yagu/common/security/SecurityConfig.java
@@ -1,6 +1,10 @@
 package yagu.yagu.common.security;
 
+
 import com.fasterxml.jackson.databind.ObjectMapper;
+import jakarta.servlet.ServletException;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import org.springframework.context.annotation.Bean;
 import org.springframework.context.annotation.Configuration;
@@ -8,12 +12,14 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.MediaType;
 import org.springframework.security.config.annotation.web.builders.HttpSecurity;
 import org.springframework.security.config.annotation.web.configuration.EnableWebSecurity;
-import org.springframework.security.config.annotation.web.configurers.AbstractHttpConfigurer;
 import org.springframework.security.config.http.SessionCreationPolicy;
+import org.springframework.security.core.Authentication;
+import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.SecurityFilterChain;
 import org.springframework.security.web.authentication.UsernamePasswordAuthenticationFilter;
 import yagu.yagu.user.service.AuthService;
 
+import java.io.IOException;
 import java.nio.charset.StandardCharsets;
 import java.util.Map;
 
@@ -22,48 +28,55 @@ import java.util.Map;
 @RequiredArgsConstructor
 public class SecurityConfig {
 
-    private final JwtTokenProvider jwtTokenProvider;
-    private final CustomOAuth2UserService customOAuth2UserService;
+    private final JwtTokenProvider jwtProvider;
+    private final CustomOAuth2UserService oauth2UserService;
     private final AuthService authService;
+    private final ObjectMapper mapper;
 
     @Bean
     public SecurityFilterChain filterChain(HttpSecurity http) throws Exception {
-        ObjectMapper mapper = new ObjectMapper();
-
         http
-                .csrf(AbstractHttpConfigurer::disable)
-                .httpBasic(AbstractHttpConfigurer::disable)
-                .sessionManagement(sm -> sm
-                        .sessionCreationPolicy(SessionCreationPolicy.STATELESS)
-                )
+                .csrf().disable()
+                .httpBasic().disable()
+                .sessionManagement(sm -> sm.sessionCreationPolicy(SessionCreationPolicy.STATELESS))
                 .authorizeHttpRequests(auth -> auth
                         .requestMatchers("/oauth2/authorization/**", "/api/auth/login/failure").permitAll()
-                        .requestMatchers("/api/auth/check").authenticated()
-                        .requestMatchers("/api/pets/**").authenticated()
+                        .requestMatchers("/api/auth/check", "/api/pets/**").authenticated()
                         .anyRequest().permitAll()
                 )
                 .oauth2Login(oauth2 -> oauth2
-                        .userInfoEndpoint(ui -> ui
-                                .userService(customOAuth2UserService)
-                        )
-                        .successHandler((req, res, auth) -> {
-                            var oauthUser = (CustomOAuth2User) auth.getPrincipal();
-                            var data = authService.createLoginResponse(oauthUser.getUser());
-                            res.setCharacterEncoding(StandardCharsets.UTF_8.name());
-                            res.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
-                            mapper.writeValue(res.getWriter(), data);
-                        })
-                        .failureHandler((req, res, ex) -> {
-                            res.setStatus(HttpStatus.UNAUTHORIZED.value());
-                            res.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
-                            mapper.writeValue(res.getWriter(), Map.of("error", ex.getMessage()));
-                        })
+                        .authorizationEndpoint(a -> a.baseUri("/oauth2/authorization"))
+                        .redirectionEndpoint(r -> r.baseUri("/login/oauth2/code/*"))
+                        .userInfoEndpoint(u -> u.userService(oauth2UserService))
+                        .successHandler(this::onSuccess)
+                        .failureHandler(this::onFailure)
                 )
                 .addFilterBefore(
-                        new JwtAuthenticationFilter(jwtTokenProvider),
+                        new JwtAuthenticationFilter(jwtProvider),
                         UsernamePasswordAuthenticationFilter.class
                 );
 
         return http.build();
+    }
+
+    private void onSuccess(HttpServletRequest req,
+                           HttpServletResponse res,
+                           Authentication auth)
+            throws IOException, ServletException {
+        var oauthUser = (CustomOAuth2User) auth.getPrincipal();
+        var data = authService.createLoginResponse(oauthUser.getUser());
+
+        res.setCharacterEncoding(StandardCharsets.UTF_8.name());
+        res.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+        mapper.writeValue(res.getWriter(), data);
+    }
+
+    private void onFailure(HttpServletRequest req,
+                           HttpServletResponse res,
+                           AuthenticationException ex)
+            throws IOException, ServletException {
+        res.setStatus(HttpStatus.UNAUTHORIZED.value());
+        res.setContentType(MediaType.APPLICATION_JSON_VALUE + ";charset=UTF-8");
+        mapper.writeValue(res.getWriter(), Map.of("error", ex.getMessage()));
     }
 }

--- a/src/main/java/yagu/yagu/common/security/SecurityConfig.java
+++ b/src/main/java/yagu/yagu/common/security/SecurityConfig.java
@@ -49,7 +49,7 @@ public class SecurityConfig {
                         .redirectionEndpoint(r -> r.baseUri("/login/oauth2/code/*"))
                         .userInfoEndpoint(u -> u
                                 .userService(oauth2UserService)
-                                .oidcUserService(oauth2UserService)
+                                .oidcUserService(oauth2UserService::loadUser)
                         )
                         .successHandler(this::onSuccess)
                         .failureHandler(this::onFailure)

--- a/src/main/java/yagu/yagu/user/controller/AuthController.java
+++ b/src/main/java/yagu/yagu/user/controller/AuthController.java
@@ -1,4 +1,42 @@
 package yagu.yagu.user.controller;
 
+import lombok.Data;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.Authentication;
+import org.springframework.web.bind.annotation.*;
+import yagu.yagu.user.entity.User;
+import yagu.yagu.user.repository.UserRepository;
+
+import java.util.Map;
+
+@RestController
+@RequestMapping("/api/auth")
+@RequiredArgsConstructor
 public class AuthController {
+    private final UserRepository repo;
+
+    /** 닉네임 중복 체크 */
+    @GetMapping("/nickname/check")
+    public ResponseEntity<Map<String,Boolean>> checkNickname(@RequestParam String nickname) {
+        boolean ok = !repo.existsByNickname(nickname);
+        return ResponseEntity.ok(Map.of("available", ok));
+    }
+
+    /** 프로필(닉네임) 완성 */
+    @PostMapping("/profile")
+    public ResponseEntity<Map<String,Boolean>> completeProfile(
+            @RequestBody ProfileReq req,
+            Authentication auth) {
+
+        String email = auth.getName();
+        User u = repo.findByEmail(email)
+                .orElseThrow(() -> new RuntimeException("사용자 없음"));
+        u.completeProfile(req.getNickname());
+        repo.save(u);
+        return ResponseEntity.ok(Map.of("profileCompleted", true));
+    }
+
+    @Data
+    static class ProfileReq { private String nickname; }
 }

--- a/src/main/java/yagu/yagu/user/controller/AuthController.java
+++ b/src/main/java/yagu/yagu/user/controller/AuthController.java
@@ -23,7 +23,7 @@ public class AuthController {
         return ResponseEntity.ok(Map.of("available", ok));
     }
 
-    /** 프로필(닉네임) 완성 */
+    /** 프로필 완성 */
     @PostMapping("/profile")
     public ResponseEntity<Map<String,Boolean>> completeProfile(
             @RequestBody ProfileReq req,

--- a/src/main/java/yagu/yagu/user/controller/AuthController.java
+++ b/src/main/java/yagu/yagu/user/controller/AuthController.java
@@ -5,8 +5,10 @@ import lombok.RequiredArgsConstructor;
 import org.springframework.http.ResponseEntity;
 import org.springframework.security.core.Authentication;
 import org.springframework.web.bind.annotation.*;
+import yagu.yagu.common.security.CustomOAuth2User;
 import yagu.yagu.user.entity.User;
 import yagu.yagu.user.repository.UserRepository;
+import yagu.yagu.user.service.AuthService;
 
 import java.util.Map;
 
@@ -14,29 +16,40 @@ import java.util.Map;
 @RequestMapping("/api/auth")
 @RequiredArgsConstructor
 public class AuthController {
-    private final UserRepository repo;
+    private final UserRepository userRepo;
+    private final AuthService authService;
 
-    /** 닉네임 중복 체크 */
-    @GetMapping("/nickname/check")
-    public ResponseEntity<Map<String,Boolean>> checkNickname(@RequestParam String nickname) {
-        boolean ok = !repo.existsByNickname(nickname);
-        return ResponseEntity.ok(Map.of("available", ok));
+    /**  로그인 상태 체크 & 유저 정보 반환 */
+    @GetMapping("/check")
+    public ResponseEntity<Map<String,Object>> checkAuth(Authentication authentication) {
+        CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
+        User user = principal.getUser();
+        Map<String,Object> data = authService.createLoginResponse(user);
+        return ResponseEntity.ok(data);
     }
 
-    /** 프로필 완성 */
+    /**  닉네임 중복 체크 */
+    @GetMapping("/nickname/check")
+    public ResponseEntity<Map<String,Boolean>> checkNickname(@RequestParam String nickname) {
+        boolean available = !userRepo.existsByNickname(nickname);
+        return ResponseEntity.ok(Map.of("available", available));
+    }
+
+    /**  프로필 완성 — profileCompleted = true 로 업뎃 */
     @PostMapping("/profile")
     public ResponseEntity<Map<String,Boolean>> completeProfile(
             @RequestBody ProfileReq req,
-            Authentication auth) {
+            Authentication authentication) {
 
-        String email = auth.getName();
-        User u = repo.findByEmail(email)
-                .orElseThrow(() -> new RuntimeException("사용자 없음"));
-        u.completeProfile(req.getNickname());
-        repo.save(u);
+        CustomOAuth2User principal = (CustomOAuth2User) authentication.getPrincipal();
+        User user = principal.getUser();
+        user.completeProfile(req.getNickname());
+        userRepo.save(user);
+
         return ResponseEntity.ok(Map.of("profileCompleted", true));
     }
 
-    @Data
-    static class ProfileReq { private String nickname; }
+    @Data static class ProfileReq {
+        private String nickname;
+    }
 }

--- a/src/main/java/yagu/yagu/user/entity/User.java
+++ b/src/main/java/yagu/yagu/user/entity/User.java
@@ -1,15 +1,13 @@
 package yagu.yagu.user.entity;
 
 import jakarta.persistence.*;
-import lombok.AllArgsConstructor;
-import lombok.Builder;
-import lombok.Getter;
-import lombok.NoArgsConstructor;
+import lombok.*;
 
 
 @Entity
 @Table(name = "users")
 @Getter
+@Setter
 @Builder
 @NoArgsConstructor
 @AllArgsConstructor
@@ -34,7 +32,14 @@ public class User {
     @Column
     private String profileImageUrl;
 
-    public enum AuthProvider {
-        KAKAO, APPLE
+    @Column(nullable = false)
+    private boolean profileCompleted;
+
+    public enum AuthProvider { GOOGLE, KAKAO, APPLE }
+
+
+    public void completeProfile(String nickname) {
+        this.nickname = nickname;
+        this.profileCompleted = true;
     }
 }

--- a/src/main/java/yagu/yagu/user/repository/UserRepository.java
+++ b/src/main/java/yagu/yagu/user/repository/UserRepository.java
@@ -7,4 +7,5 @@ import java.util.Optional;
 
 public interface UserRepository extends JpaRepository<User, Long> {
     Optional<User> findByEmail(String email);
+    boolean existsByNickname(String nickname);
 }


### PR DESCRIPTION
## 소셜 로그인 + JWT 발급 및 회원가입 구현
- 카카오 -> DefaultOAuth2UserService
- 애플, 구글 -> OidcUserService
- 애플 로그인은 추후 애플 developer 프로그램 가입 후 키 값 입력 
- 소셜 로그인을 통해 회원가입 후 닉네임까지 등록해야 회원등록 완료.