### PR TITLE
[#51] /api/diaries/month 성능 최적화

### DIFF
--- a/src/main/java/yagu/yagu/diary/entity/GameDiary.java
+++ b/src/main/java/yagu/yagu/diary/entity/GameDiary.java
@@ -28,6 +28,7 @@ public class GameDiary {
     @JoinColumn(name = "game_id", nullable = false)
     private KboGame game;
 
+
     @Column(name = "favorite_team")
     private String favoriteTeam;
 

--- a/src/main/java/yagu/yagu/diary/service/GameDiaryService.java
+++ b/src/main/java/yagu/yagu/diary/service/GameDiaryService.java
@@ -38,11 +38,9 @@ public class GameDiaryService {
                 return toDto(d);
         }
 
+        @Transactional(readOnly = true)
         public List<GameDiaryDetailDTO> getAllDiaries(Long userId) {
-                return diaryRepo.findAllByUserIdOrderByGame_GameDateDesc(userId)
-                                .stream()
-                                .map(this::toDto)
-                                .collect(Collectors.toList());
+                return diaryRepo.findAllDtosByUser(userId);
         }
 
         @Transactional
@@ -159,14 +157,11 @@ public class GameDiaryService {
                 statsRepo.save(stats);
         }
 
+        @Transactional(readOnly = true)
         public List<GameDiaryDetailDTO> getDiariesByMonth(Long userId, int year, int month) {
                 LocalDate start = LocalDate.of(year, month, 1);
-                LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
-
-                return diaryRepo.findAllByUserIdAndGame_GameDateBetweenOrderByGame_GameDateDesc(userId, start, end)
-                                .stream()
-                                .map(this::toDto)
-                                .collect(Collectors.toList());
+                LocalDate endExclusive = start.plusMonths(1);
+                return diaryRepo.findMonthDtos(userId, start, endExclusive);
         }
 
         @Transactional


### PR DESCRIPTION
## /api/diaries/month 성능 최적화
- DB 인덱스 추가
- 조회 로직 개선 : DTO 프로젝션 기반 단건 조인 조회 → 필요한 필드만 SELECT, N+1 제거.
- 페이로드 최적화