### PR TITLE
[#53] Game Redis 적용

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -60,6 +60,10 @@ dependencies {
 	// Spring Batch
 	implementation 'org.springframework.boot:spring-boot-starter-batch'
 
+	//redis
+	implementation 'org.springframework.boot:spring-boot-starter-data-redis'
+	implementation 'com.fasterxml.jackson.core:jackson-databind'
+
 }
 
 tasks.named('test') {

--- a/src/main/java/yagu/yagu/game/cache/CalendarCacheKeys.java
+++ b/src/main/java/yagu/yagu/game/cache/CalendarCacheKeys.java
@@ -1,0 +1,10 @@
+package yagu.yagu.game.cache;
+
+import java.time.YearMonth;
+
+public final class CalendarCacheKeys {
+    private CalendarCacheKeys() {}
+    public static final String YEARS_SET = "games:calendar:years";
+    public static String monthKey(YearMonth ym) { return String.format("games:calendar:%04d-%02d", ym.getYear(), ym.getMonthValue()); }
+    public static String yearIndexKey(int year) { return String.format("games:calendar:index:%04d", year); }
+}

--- a/src/main/java/yagu/yagu/game/cache/GameCalendarCacheScheduler.java
+++ b/src/main/java/yagu/yagu/game/cache/GameCalendarCacheScheduler.java
@@ -1,0 +1,57 @@
+package yagu.yagu.game.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.RedisCallback;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.scheduling.annotation.Scheduled;
+import org.springframework.stereotype.Component;
+
+import java.nio.charset.StandardCharsets;
+import java.time.Year;
+import java.time.ZoneId;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Set;
+
+import static yagu.yagu.game.cache.CalendarCacheKeys.YEARS_SET;
+import static yagu.yagu.game.cache.CalendarCacheKeys.yearIndexKey;
+
+@Component
+@RequiredArgsConstructor
+public class GameCalendarCacheScheduler {
+    private final GameCalendarCacheService cache;
+    private final StringRedisTemplate redis;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+
+    @Scheduled(cron = "0 25 0 * * *", zone = "Asia/Seoul")
+    public void refreshAndKeepOnlyCurrentYear() {
+        cache.refreshCurrentMonth();
+
+
+        int curYear = Year.now(KST).getValue();
+        Set<String> years = redis.opsForSet().members(YEARS_SET);
+        if (years == null || years.isEmpty()) return;
+
+
+        List<String> removeYears = new ArrayList<>();
+        for (String y : years) {
+            if (!String.valueOf(curYear).equals(y)) {
+                String indexKey = yearIndexKey(Integer.parseInt(y));
+                Set<String> keys = redis.opsForSet().members(indexKey);
+                redis.executePipelined((RedisCallback<Object>) conn -> {
+                    if (keys != null) {
+                        for (String k : keys) conn.keyCommands().del(k.getBytes(StandardCharsets.UTF_8));
+                    }
+                    conn.keyCommands().del(indexKey.getBytes(StandardCharsets.UTF_8));
+                    return null;
+                });
+                removeYears.add(y);
+            }
+        }
+        if (!removeYears.isEmpty()) {
+            redis.opsForSet().remove(YEARS_SET, removeYears.toArray());
+            redis.opsForSet().add(YEARS_SET, String.valueOf(curYear));
+        }
+    }
+}

--- a/src/main/java/yagu/yagu/game/cache/GameCalendarCacheService.java
+++ b/src/main/java/yagu/yagu/game/cache/GameCalendarCacheService.java
@@ -1,0 +1,89 @@
+package yagu.yagu.game.cache;
+
+
+import com.fasterxml.jackson.core.type.TypeReference;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import lombok.RequiredArgsConstructor;
+import org.springframework.data.redis.core.StringRedisTemplate;
+import org.springframework.stereotype.Service;
+import yagu.yagu.game.dto.KboGameDTO;
+import yagu.yagu.game.repository.KboGameRepository;
+
+import java.time.LocalDate;
+import java.time.Year;
+import java.time.YearMonth;
+import java.time.ZoneId;
+import java.util.List;
+import java.util.stream.Collectors;
+
+@Service
+@RequiredArgsConstructor
+public class GameCalendarCacheService {
+    private final StringRedisTemplate redis;
+    private final ObjectMapper om;
+    private final KboGameRepository repo;
+    private static final ZoneId KST = ZoneId.of("Asia/Seoul");
+
+
+    /** 컨트롤러에서 호출: 월별 경기 (현재 연도면 캐시 사용/쓰기) */
+    public List<KboGameDTO> getMonthly(int year, int month) {
+        YearMonth ym = YearMonth.of(year, month);
+        int curYear = Year.now(KST).getValue();
+        String key = CalendarCacheKeys.monthKey(ym);
+
+
+        if (year == curYear) {
+            String json = redis.opsForValue().get(key);
+            if (json != null) return fromJson(json);
+            List<KboGameDTO> list = loadFromDb(ym);
+            putMonth(ym, list); // 무기한 저장 + 인덱스 등록(올해만)
+            return list;
+        } else {
+            String json = redis.opsForValue().get(key);
+            return (json != null) ? fromJson(json) : loadFromDb(ym);
+        }
+    }
+
+
+    /** 매일 00:25에 현재 달 강제 최신화 */
+    public void refreshCurrentMonth() {
+        YearMonth now = YearMonth.now(KST);
+        putMonth(now, loadFromDb(now));
+    }
+
+
+    /** 앱 기동 시 1회 워밍(1월~현재달) */
+    public void warmCurrentYearUpToNow() {
+        YearMonth now = YearMonth.now(KST);
+        YearMonth cur = YearMonth.of(now.getYear(), 1);
+        for (; !cur.isAfter(now); cur = cur.plusMonths(1)) {
+            putMonth(cur, loadFromDb(cur));
+        }
+    }
+
+
+    // --- 내부 유틸 ---
+    private List<KboGameDTO> loadFromDb(YearMonth ym) {
+        LocalDate start = ym.atDay(1);
+        LocalDate end = ym.atEndOfMonth();
+        return repo.findByGameDateBetween(start, end).stream().map(KboGameDTO::new).collect(Collectors.toList());
+    }
+
+
+    private void putMonth(YearMonth ym, List<KboGameDTO> list) {
+        int curYear = Year.now(KST).getValue();
+        if (ym.getYear() != curYear) return;
+        String key = CalendarCacheKeys.monthKey(ym);
+        try {
+            redis.opsForValue().set(key, om.writeValueAsString(list));
+        } catch (Exception e) { throw new RuntimeException(e); }
+        redis.opsForSet().add(CalendarCacheKeys.yearIndexKey(curYear), key);
+        redis.opsForSet().add(CalendarCacheKeys.YEARS_SET, String.valueOf(curYear));
+    }
+
+
+    private List<KboGameDTO> fromJson(String json) {
+        try { return om.readValue(json, new TypeReference<List<KboGameDTO>>(){}); }
+        catch (Exception e) { throw new RuntimeException(e); }
+    }
+}

--- a/src/main/java/yagu/yagu/game/cache/GameCalendarWarmupRunner.java
+++ b/src/main/java/yagu/yagu/game/cache/GameCalendarWarmupRunner.java
@@ -1,0 +1,19 @@
+package yagu.yagu.game.cache;
+
+import lombok.RequiredArgsConstructor;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.boot.CommandLineRunner;
+import org.springframework.context.annotation.Bean;
+import org.springframework.context.annotation.Configuration;
+
+@Configuration
+@RequiredArgsConstructor
+public class GameCalendarWarmupRunner {
+    private final GameCalendarCacheService cache;
+
+
+    @Bean
+    CommandLineRunner warmOnStart(@Value("${cache.calendar.warm-on-start:true}") boolean enabled) {
+        return args -> { if (enabled) cache.warmCurrentYearUpToNow(); };
+    }
+}

--- a/src/main/java/yagu/yagu/game/controller/GameController.java
+++ b/src/main/java/yagu/yagu/game/controller/GameController.java
@@ -6,6 +6,7 @@ import org.springframework.web.bind.annotation.*;
 import yagu.yagu.common.exception.BusinessException;
 import yagu.yagu.common.exception.ErrorCode;
 import yagu.yagu.common.response.ApiResponse;
+import yagu.yagu.game.cache.GameCalendarCacheService;
 import yagu.yagu.game.dto.KboGameDTO;
 import yagu.yagu.game.entity.KboGame;
 import yagu.yagu.game.repository.KboGameRepository;
@@ -19,9 +20,11 @@ import java.util.stream.Collectors;
 public class GameController {
 
     private final KboGameRepository gameRepo;
+    private final GameCalendarCacheService calendarCache;
 
-    public GameController(KboGameRepository gameRepo) {
+    public GameController(KboGameRepository gameRepo, GameCalendarCacheService calendarCache) {
         this.gameRepo = gameRepo;
+        this.calendarCache = calendarCache;
     }
 
     /** 날짜별 경기 조회 */
@@ -47,22 +50,12 @@ public class GameController {
 
     /** 월별 캘린더용 조회 (쿼리 파라미터) */
     @GetMapping("/calendar")
-    public ResponseEntity<ApiResponse<List<KboGameDTO>>> getMonthlyGames(
-            @RequestParam int year,
-            @RequestParam int month) {
-        if (year < 1900 || year > 2100) {
-            throw new BusinessException(ErrorCode.GAME_DATE_INVALID, "연도는 1900~2100 사이여야 합니다.");
-        }
-        if (month < 1 || month > 12) {
-            throw new BusinessException(ErrorCode.GAME_DATE_INVALID, "월은 1~12 사이여야 합니다.");
-        }
+    public ResponseEntity<ApiResponse<List<KboGameDTO>>> getMonthlyGames(@RequestParam int year, @RequestParam int month) {
+        if (year < 1900 || year > 2100) throw new BusinessException(ErrorCode.GAME_DATE_INVALID, "연도는 1900~2100 사이여야 합니다.");
+        if (month < 1 || month > 12) throw new BusinessException(ErrorCode.GAME_DATE_INVALID, "월은 1~12 사이여야 합니다.");
 
-        LocalDate start = LocalDate.of(year, month, 1);
-        LocalDate end = start.withDayOfMonth(start.lengthOfMonth());
-        List<KboGameDTO> dtos = gameRepo.findByGameDateBetween(start, end).stream()
-                .map(KboGameDTO::new)
-                .collect(Collectors.toList());
 
+        List<KboGameDTO> dtos = calendarCache.getMonthly(year, month);
         return ResponseEntity.ok(ApiResponse.success(dtos, "월별 경기 조회 완료"));
     }
 }

--- a/src/main/java/yagu/yagu/game/dto/KboGameDTO.java
+++ b/src/main/java/yagu/yagu/game/dto/KboGameDTO.java
@@ -3,6 +3,7 @@ package yagu.yagu.game.dto;
 import com.fasterxml.jackson.annotation.JsonFormat;
 import lombok.AllArgsConstructor;
 import lombok.Data;
+import lombok.NoArgsConstructor;
 import yagu.yagu.game.entity.KboGame;
 
 
@@ -11,6 +12,7 @@ import java.time.LocalTime;
 
 @Data
 @AllArgsConstructor
+@NoArgsConstructor
 public class KboGameDTO {
     private Long id;
     private LocalDate gameDate;


### PR DESCRIPTION
## 캐시 적용 

- GameCalendarCacheService 추가
월별 경기 데이터를 Redis에 캐싱 (games:calendar:{yyyy}-{MM})
올해 연도만 캐시 관리, 과거 연도 키는 자동 정리
캐시 미스 시 DB 조회 후 Redis에 저장

- GameCalendarCacheScheduler 추가
매일 00:25 현재 달 데이터 강제 리프레시
스케줄 실행 시 이전 연도 데이터 키 정리 (12개월 롤링 유지)

- GameController 수정
/api/games/calendar → DB 조회 대신 calendarCache.getMonthly(year, month) 사용

- Redis 연동 환경 구성
